### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(ci): "
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds: .github/dependabot.yml — daily, grouped version updates for GitHub Actions, matching our other product repos (PLT-1/TEMP-1/AIR-1).

Does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency update checks for GitHub Actions on a daily schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->