### PR TITLE
Add Release Drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+name-template: 'Release v$NEXT_PATCH_VERSION'
+tag-template: "$RESOLVED_VERSION"
+change-template: "- #$NUMBER $TITLE @$AUTHOR"
+sort-direction: ascending
+
+categories:
+  - title: "🚨 Breaking changes"
+    labels:
+      - "breaking-change"
+  - title: "✨ New features"
+    labels:
+      - "new-feature"
+  - title: "🐛 Bug fixes"
+    labels:
+      - "bugfix"
+#  - title: "🚀 Enhancements"
+#    labels:
+#      - "enhancement"
+#      - "refactor"
+#      - "performance"
+#  - title: "🧰 Maintenance"
+#    labels:
+#      - "maintenance"
+#      - "ci"
+#  - title: "📚 Documentation"
+#    labels:
+#      - "documentation"
+  - title: "⬆️ Dependency updates"
+    collapse-after: 5
+    labels:
+      - "dependency-update"
+#  - title: "🚨🚨 Security Fixes 🚨🚨"
+#    labels:
+#      - "security"
+
+
+include-labels:
+  - "bugfix"
+  - "new-feature"
+  - "breaking-change"
+
+no-changes-template: '- No changes'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/ApolloAutomation/CAST-1/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
+
+   Be sure to 🌟 this repository for updates!


### PR DESCRIPTION
Adds: .github/release-drafter.yml — auto-drafts release notes from PR labels (bugfix / new-feature / breaking-change / dependency-update), matching our other product repos. Compare URL points at CAST-1; the required labels already exist on the repo.

Does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)