### PR TITLE
Add detailed pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
+-->
+Version:
+
+<!--
+  You are amazing! Thanks for contributing to our project!
+  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
+-->
+## What does this implement/fix?
+
+
+
+## Types of changes
+<!--
+  What type of change does your PR introduce?
+  NOTE: Please, check only 1! box!
+  If your PR requires multiple boxes to be checked, you'll most likely need to
+  split it into multiple PRs. This makes things easier and faster to code review.
+-->
+
+- [ ] Bugfix (fixed change that fixes an issue)
+- [ ] New feature (thanks!)
+- [ ] Breaking change (repair/feature that breaks existing functionality)
+- [ ] Dependency Update - Does not publish
+- [ ] Other - Does not publish
+- [ ] Website of github readme file update - Does not publish
+- [ ] Github workflows - Does not publish
+
+
+## Checklist / Checklijst:
+<!--
+  Put an x in the boxes that apply. You can also fill these out after
+  creating the PR. If you're unsure about any of them, don't hesitate to ask.
+  We're here to help! This is simply a reminder of what we are going to look
+  for before merging your code.
+-->
+
+  - [ ] The code change has been tested and works locally
+  - [ ] The code change has not yet been tested
+  
+If user-visible functionality or configuration variables are added/modified:
+  - [ ] Added/updated documentation for the web page
+
+<!--
+  Thank you for contributing <3
+-->


### PR DESCRIPTION
Adds: .github/PULL_REQUEST_TEMPLATE.md — the detailed contributor template (types of changes + checklist) used across our other product repos. The repo currently only has the short root template; this matches the PLT-1/TEMP-1/AIR-1 convention of keeping both.

Does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)