### PR TITLE
Bump actions/checkout to v6.0.3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.3
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7
         with:


### PR DESCRIPTION
Fixes: ci.yml pinned actions/checkout@v5.0.0; other product repos use v6.0.3.

Does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)