### PR TITLE
Update autoassign: bump action to v4, assign to bharvey88

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -12,8 +12,8 @@ jobs:
       pull-requests: write
     steps:
     - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
+      uses: pozil/auto-assign-issue@v4
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: TrevorSchirmer
+          assignees: bharvey88
           numOfAssignee: 1


### PR DESCRIPTION
Fixes: .github/workflows/autoassign.yml
- Bump pozil/auto-assign-issue v1 → v4 (matches other product repos)
- Change issue assignee TrevorSchirmer → bharvey88

Does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)