### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# Apollo CAST-1
 
+<!-- Brandon: drop CAST_Card.png here, then update the path below -->
+![Apollo CAST-1](https://placehold.co/800x400?text=CAST-1)
+
+Easily make your speakers smart and cast to multiple devices using Music Assistant and Sendspin!
+
+Links: \
+Discord (Support/feedback/discussion/future products): [http://dsc.gg/ApolloAutomation](http://dsc.gg/ApolloAutomation) \
+Shop: [https://apolloautomation.com](https://apolloautomation.com) \
+Wiki: [https://wiki.apolloautomation.com](https://wiki.apolloautomation.com/)


### PR DESCRIPTION
Adds: README.md — the repo previously had an empty README. Adds a product blurb and the standard Discord / Shop / Wiki links, matching our other product repos. Uses a placeholder card image for now (left a comment to swap in CAST_Card.png).

Does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)