### PR TITLE
Remove stale BLE wifi toggle

### DIFF
--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -54,12 +54,9 @@ update:
 logger:
 
 wifi:
-  id: wifi_1
   on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
+    - component.update: update_http_request
+  id: wifi_1
   ap:
     ssid: "Apollo CAST 1 Hotspot"
 


### PR DESCRIPTION
Removes the wifi on_connect/on_disconnect BLE enable/disable block from CAST-1_W.yaml — the same toggle that was removed from R_PRO-1. CAST-1 has no BLE config of its own (the actions only resolved via esp32_improv), so dropping it is safe. Replaces on_connect with `component.update: update_http_request` to refresh the OTA manifest source, matching R_PRO-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)