### PR TITLE
Pin web_server to version 3

### DIFF
--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -39,6 +39,7 @@ safe_mode:
 
 web_server:
   port: 80
+  version: 3
 
 update:
   - platform: http_request

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -44,6 +44,7 @@ esp32_improv:
 
 web_server:
   port: 80
+  version: 3
 
 update:
   - platform: http_request


### PR DESCRIPTION
Adds `version: 3` to the web_server block in CAST-1_W.yaml and CAST-1_ETH.yaml. Every other current product repo (R_PRO-1, MTR-1, PLT-1, BTN-1, MSR-2) pins v3; CAST-1 was the only one left on the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)