### PR TITLE
Add ESPHome and Apollo firmware version sensors

### DIFF
--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -21,7 +21,12 @@ esphome:
               - lambda: "return id(runTest);"
             then:
               - lambda: "id(testScript).execute();"
-  
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/CAST-1/Integrations/ESPHome/CAST-1_ETH.yaml
   import_full_config: false

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -88,5 +88,12 @@ select:
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json");
               - component.update: update_http_request
 
+text_sensor:
+  - platform: ethernet_info
+    ip_address:
+      name: "IP Address"
+      id: eth_ip
+      entity_category: "diagnostic"
+
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -96,5 +96,12 @@ select:
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json");
               - component.update: update_http_request
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+      entity_category: "diagnostic"
+
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -21,7 +21,12 @@ esphome:
               - lambda: "return id(runTest);"
             then:
               - lambda: "id(testScript).execute();"
-  
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/CAST-1/Integrations/ESPHome/CAST-1_W.yaml
   import_full_config: false

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -145,6 +145,17 @@ text_sensor:
     type: album
     name: Album
 
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    update_interval: never
+    entity_category: "diagnostic"
+
 light:
   - platform: esp32_rmt_led_strip
     id: rgb_light


### PR DESCRIPTION
Adds diagnostic text sensors to match R_PRO-1:

Core.yaml (both variants):
- "ESPHome Version" (platform: version)
- "Apollo Firmware Version" (template), published on boot from the ${version} substitution via an on_boot priority-500 hook in both device YAMLs.

Per-variant IP address (entity_category: diagnostic):
- CAST-1_W.yaml: wifi_info → "IP Address" (wifi_ip)
- CAST-1_ETH.yaml: ethernet_info → "IP Address" (eth_ip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device firmware version reporting as a diagnostic sensor
  * Added IP address diagnostic sensors for network connectivity visibility (Ethernet and WiFi)
  * Added ESPHome version reporting in diagnostic information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->