### PR TITLE
Normalize apply_ducking indentation in Core.yaml

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -312,9 +312,9 @@ media_player:
                 green: 100%
                 brightness: 50%
             - mixer_speaker.apply_ducking:
-                  id: media_mixer_input
-                  decibel_reduction: 40
-                  duration: 0.0s
+                id: media_mixer_input
+                decibel_reduction: 40
+                duration: 0.0s
             - wait_until:
                 media_player.is_announcing: external_media_player
             - delay: 0.75s
@@ -325,9 +325,9 @@ media_player:
                 - not:
                     media_player.is_announcing: external_media_player
             - mixer_speaker.apply_ducking:
-                      id: media_mixer_input
-                      decibel_reduction: 0
-                      duration: 1.0s
+                id: media_mixer_input
+                decibel_reduction: 0
+                duration: 1.0s
             - media_player.volume_set:
                 id: external_media_player
                 volume: !lambda "return id(current_volume);"


### PR DESCRIPTION
Version: 26.5.27.1

## What does this implement/fix?

The `id:`/`decibel_reduction:`/`duration:` keys under the two `on_announcement` `apply_ducking` blocks were over-indented relative to the rest of the file. Re-indent them to a consistent level. No functional change — YAML parses identically.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [x] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)