### PR TITLE
Consolidate web_server into Core.yaml (keep version 3)

### DIFF
--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -42,10 +42,6 @@ http_request:
 
 safe_mode:
 
-web_server:
-  port: 80
-  version: 3
-
 update:
   - platform: http_request
     id: update_http_request

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -47,10 +47,6 @@ improv_serial:
 esp32_improv:
   authorizer: none
 
-web_server:
-  port: 80
-  version: 3
-
 update:
   - platform: http_request
     id: update_http_request

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -52,8 +52,9 @@ psram:
   mode: octal
   speed: 80MHz
 
-web_server:  
+web_server:
   port: 80
+  version: 3
 
 i2c:
   sda: GPIO47


### PR DESCRIPTION
Version: 26.5.27.1

## What does this implement/fix?

`web_server:` was defined in both Core.yaml (`port: 80`) and each device config (`port: 80` + `version: 3`, added in #14). Core.yaml is included by both, so this moves `version: 3` into Core's `web_server:` block and drops the device-level copies. The port and frontend version now live in one place; package merge keeps compiled output identical.

Rebased on current `beta` — `version: 3` is preserved (carried into Core), not dropped.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [x] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)