### PR TITLE
Remove orphaned announcement_resampling_speaker?

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.5.27.1"
+  version: "26.6.16.1"
 
 esp32:
   variant: ESP32S3
@@ -241,13 +241,6 @@ speaker:
   - platform: resampler
     id: media_resampling_speaker
     output_speaker: media_mixer_input
-    task_stack_in_psram: true
-    sample_rate: 48000
-    bits_per_sample: 16
-
-  - platform: resampler
-    id: announcement_resampling_speaker
-    output_speaker: announcement_mixer_input
     task_stack_in_psram: true
     sample_rate: 48000
     bits_per_sample: 16


### PR DESCRIPTION
Version: 26.6.16.1

## What does this implement/fix?

Proposing removal of the `announcement_resampling_speaker` resampler — flagging for confirmation before merge.

Tracing the signal path, it looks orphaned:
- `media_pipeline` → `media_resampling_speaker` → `media_mixer_input` ✅ (resampler is in the chain)
- `announcement_pipeline` writes straight to `announcement_mixer_input` (`speaker: announcement_mixer_input`), so nothing ever feeds into `announcement_resampling_speaker`.

The announcement pipeline already declares `sample_rate: 48000`, which matches the I2S output, so no resampling is needed on that path. As-is the resampler is never in the signal path but still reserves a PSRAM task stack.

Question: is this intentional (e.g. reserved for future use), or safe to remove? If announcements should be resampled, the fix is the opposite — point `announcement_pipeline.speaker` at the resampler instead. Closing this is fine if it's meant to stay.

Tracking: #17

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)