### PR TITLE
Disable WiFi post-connect roaming on CAST-1_W

### DIFF
--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -59,6 +59,10 @@ wifi:
   on_connect:
     - component.update: update_http_request
   id: wifi_1
+  # Temporary workaround: post-connect roam scans briefly drop the Music
+  # Assistant stream mid-playback even on a strong signal. Remove this once
+  # esphome stops roaming from interrupting active playback.
+  post_connect_roaming: false
   ap:
     ssid: "Apollo CAST 1 Hotspot"
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.6.16.1"
+  version: "26.6.17.1"
 
 esp32:
   variant: ESP32S3


### PR DESCRIPTION
Version: 26.6.17.1

## What does this implement/fix?

Sets `post_connect_roaming: false` on the WiFi (CAST-1_W) config. Post-connect roam scans briefly drop the Music Assistant (sendspin) stream mid-playback — observed even on a strong signal (~-59 dBm), causing a ~1s audio dropout before auto-reconnect.

This is a **temporary workaround** until esphome stops roaming from interrupting active playback; the inline comment notes it should be removed once that lands upstream. ETH variant is unaffected (no WiFi).

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WiFi stability to reduce playback interruptions.

* **Chores**
  * Updated core version to 26.6.17.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->