### PR TITLE
Fix auto-assign 403 on fork PRs

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -2,7 +2,7 @@ name: Auto Assign
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
   run:


### PR DESCRIPTION
Auto-assign fails on PRs opened from forks with:

    Resource not accessible by integration (403)
    add-assignees

For `pull_request` runs triggered from a fork, GitHub forces the
GITHUB_TOKEN to read-only and ignores the workflow's `permissions:`
block, so the add-assignees call is rejected.

Switching the trigger to `pull_request_target` runs the workflow in
the base-repo context, which keeps the read/write token for fork PRs.
Safe here because the workflow only calls the assign API — it never
checks out or executes PR code.

Takes effect for PRs opened after this merges (pull_request_target
uses the workflow file on the base branch, so it won't retroactively
fix existing PRs like #21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)