### PR TITLE
Release: merge beta into main

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -2,7 +2,7 @@ name: Auto Assign
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
   run:

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -54,10 +54,10 @@ ethernet:
   type: W5500
   clk_pin: GPIO41
   mosi_pin: GPIO40
-  miso_pin: GPIO35
+  miso_pin: GPIO38
   cs_pin: GPIO42
   interrupt_pin: GPIO2
-  reset_pin: GPIO36
+  reset_pin: GPIO39
 
 select:
   - platform: template

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -42,10 +42,6 @@ http_request:
 
 safe_mode:
 
-web_server:
-  port: 80
-  version: 3
-
 update:
   - platform: http_request
     id: update_http_request

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -21,7 +21,12 @@ esphome:
               - lambda: "return id(runTest);"
             then:
               - lambda: "id(testScript).execute();"
-  
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/CAST-1/Integrations/ESPHome/CAST-1_ETH.yaml
   import_full_config: false

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -39,6 +39,7 @@ safe_mode:
 
 web_server:
   port: 80
+  version: 3
 
 update:
   - platform: http_request

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -88,5 +88,12 @@ select:
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json");
               - component.update: update_http_request
 
+text_sensor:
+  - platform: ethernet_info
+    ip_address:
+      name: "IP Address"
+      id: eth_ip
+      entity_category: "diagnostic"
+
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -96,5 +96,12 @@ select:
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json");
               - component.update: update_http_request
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+      entity_category: "diagnostic"
+
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -47,10 +47,6 @@ improv_serial:
 esp32_improv:
   authorizer: none
 
-web_server:
-  port: 80
-  version: 3
-
 update:
   - platform: http_request
     id: update_http_request

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -44,6 +44,7 @@ esp32_improv:
 
 web_server:
   port: 80
+  version: 3
 
 update:
   - platform: http_request

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -54,12 +54,9 @@ update:
 logger:
 
 wifi:
-  id: wifi_1
   on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
+    - component.update: update_http_request
+  id: wifi_1
   ap:
     ssid: "Apollo CAST 1 Hotspot"
 

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -59,6 +59,10 @@ wifi:
   on_connect:
     - component.update: update_http_request
   id: wifi_1
+  # Temporary workaround: post-connect roam scans briefly drop the Music
+  # Assistant stream mid-playback even on a strong signal. Remove this once
+  # esphome stops roaming from interrupting active playback.
+  post_connect_roaming: false
   ap:
     ssid: "Apollo CAST 1 Hotspot"
 

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -21,7 +21,12 @@ esphome:
               - lambda: "return id(runTest);"
             then:
               - lambda: "id(testScript).execute();"
-  
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/CAST-1/Integrations/ESPHome/CAST-1_W.yaml
   import_full_config: false

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.5.27.1"
+  version: "26.6.16.1"
 
 esp32:
   variant: ESP32S3
@@ -241,13 +241,6 @@ speaker:
   - platform: resampler
     id: media_resampling_speaker
     output_speaker: media_mixer_input
-    task_stack_in_psram: true
-    sample_rate: 48000
-    bits_per_sample: 16
-
-  - platform: resampler
-    id: announcement_resampling_speaker
-    output_speaker: announcement_mixer_input
     task_stack_in_psram: true
     sample_rate: 48000
     bits_per_sample: 16

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -145,6 +145,17 @@ text_sensor:
     type: album
     name: Album
 
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    update_interval: never
+    entity_category: "diagnostic"
+
 light:
   - platform: esp32_rmt_led_strip
     id: rgb_light

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.6.16.1"
+  version: "26.6.17.1"
 
 esp32:
   variant: ESP32S3

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -52,8 +52,9 @@ psram:
   mode: octal
   speed: 80MHz
 
-web_server:  
+web_server:
   port: 80
+  version: 3
 
 i2c:
   sda: GPIO47

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -312,9 +312,9 @@ media_player:
                 green: 100%
                 brightness: 50%
             - mixer_speaker.apply_ducking:
-                  id: media_mixer_input
-                  decibel_reduction: 40
-                  duration: 0.0s
+                id: media_mixer_input
+                decibel_reduction: 40
+                duration: 0.0s
             - wait_until:
                 media_player.is_announcing: external_media_player
             - delay: 0.75s
@@ -325,9 +325,9 @@ media_player:
                 - not:
                     media_player.is_announcing: external_media_player
             - mixer_speaker.apply_ducking:
-                      id: media_mixer_input
-                      decibel_reduction: 0
-                      duration: 1.0s
+                id: media_mixer_input
+                decibel_reduction: 0
+                duration: 1.0s
             - media_player.volume_set:
                 id: external_media_player
                 volume: !lambda "return id(current_volume);"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.5.27.1"
+  version: "26.6.17.1"
 
 esp32:
   variant: ESP32S3


### PR DESCRIPTION
Promote accumulated `beta` changes to `main` (18 commits ahead, 0 behind, no conflicts).

Included:
- Disable WiFi post-connect roaming on CAST-1_W (#21)
- Fix auto-assign 403 on fork PRs (#22)
- Add ESPHome + Apollo firmware version diagnostic sensors (#15)
- Add IP address diagnostic sensors — wifi_info / ethernet_info (#15)
- Pin web_server to version 3 / consolidate into Core.yaml (#14, #19)
- Remove orphaned announcement_resampling_speaker (#20)
- Remove stale BLE wifi toggle from CAST-1_W (#13)
- Normalize Core.yaml whitespace / apply_ducking indentation (#18)
- Fixes Ethernet Pins (#24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)