### PR TITLE
Publish with esphome stable for core pcm5122

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         Integrations/ESPHome/CAST-1_W.yaml
       firmware-names: "1_ETH:firmware-e,1_W:firmware-w"
       core-yaml-path: Integrations/ESPHome/Core.yaml
-      esphome-version: 2026.5.3
+      esphome-version: stable
       # Bypass check if manually triggered with bypass option
       check-yaml-changes: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.bypass-yaml-check == 'true') }}
       publish-to-pages: true


### PR DESCRIPTION
Version: 26.6.17.1

## What does this implement/fix?

Reverts the publish workflow's `esphome-version` pin (`2026.5.3`) back to `stable` (now 2026.6.0).

Context: the `2026.5.3` pin keeps the current sonocotta-based firmware building, because that external component breaks on esphome 2026.6 (`cv.only_with_esp_idf` was removed). The core `pcm5122` migration requires 2026.6.0, so the publish must use stable again.

**Pairs with the pcm5122 migration PR — merge this one first.** On its own this changes no YAML, so it doesn't trigger a firmware rebuild; it just sets the publish version so the migration publishes correctly.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [x] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build workflow now uses the latest stable ESPHome release instead of a pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->