### PR TITLE
Switch PCM5122 to core component

### DIFF
--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -11,7 +11,7 @@ esphome:
     name: "ApolloAutomation.CAST-1-ETH"
     version: ${version}
 
-  min_version: 2026.5.0
+  min_version: 2026.6.0
 
   on_boot:
     - priority: 800

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -11,7 +11,7 @@ esphome:
     name: "ApolloAutomation.CAST-1-W"
     version: ${version}
 
-  min_version: 2026.5.0
+  min_version: 2026.6.0
 
   on_boot:
     - priority: 800

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.6.17.1"
+  version: "26.6.18.1"
 
 esp32:
   variant: ESP32S3

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -322,17 +322,20 @@ media_player:
             - lambda: id(announcement_triggered) = false;
 
     on_state:
-      if:
-        condition:
-          and:
-            - lambda: return (!id(announcement_triggered));
-            - not:
-                media_player.is_announcing: external_media_player
-        then:
-          - mixer_speaker.apply_ducking:
-              id: media_mixer_input
-              decibel_reduction: 0
-              duration: 1.0s
+      # Core pcm5122 boots muted; nothing else unmutes the external DAC, so
+      # unmute it on every state change (idempotent).
+      - audio_dac.mute_off: external_dac
+      - if:
+          condition:
+            and:
+              - lambda: return (!id(announcement_triggered));
+              - not:
+                  media_player.is_announcing: external_media_player
+          then:
+            - mixer_speaker.apply_ducking:
+                id: media_mixer_input
+                decibel_reduction: 0
+                duration: 1.0s
 
 
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -61,11 +61,6 @@ i2c:
   scl: GPIO48
   id: bus_a
 
-external_components:
-  - source: github://sonocotta/esphome-pcm5122
-    components: [ pcm5122 ]
-    refresh: 24h
-
 button:
   - platform: restart
     icon: mdi:power-cycle
@@ -127,12 +122,12 @@ switch:
   - platform: factory_reset
     id: factory_reset_switch
     disabled_by_default: true
-  - platform: pcm5122
-    enable_dac:
-      name: Enable DAC
-      id: enable_dac
-      restore_mode: ALWAYS_ON
-    
+  - platform: gpio
+    pin: GPIO21
+    name: Enable DAC
+    id: enable_dac
+    restore_mode: ALWAYS_ON
+
 text_sensor:
   - platform: sendspin
     type: title
@@ -204,12 +199,9 @@ remote_receiver:
 audio_dac:
   - platform: pcm5122
     id: external_dac
+    i2c_id: bus_a
     address: 0x4D
-    enable_pin: GPIO21
-    volume_max: 0dB
-    volume_min: -60dB
-    analog_gain: -6dB
-    mixer_mode: STEREO
+    bits_per_sample: 16bit
 
 i2s_audio:
 - id: i2s_out


### PR DESCRIPTION
Version: 26.6.18.1

## What does this implement/fix?

Switches the PCM5122 DAC from `github://sonocotta/esphome-pcm5122` to the core `pcm5122` component added in esphome 2026.6.0 (esphome/esphome#15709). Drops the external dependency and unblocks esphome 2026.6 — the sonocotta component fails to load on 2026.6 (uses the removed `cv.only_with_esp_idf`), so the current firmware can't build on 2026.6 without this.

Requires esphome >= 2026.6.0 (min_version bumped). **Pairs with #27** (publish build → esphome stable); merge #27 first so the firmware publishes on 2026.6.0.

The core component is more minimal, so the config changed:
- audio_dac trimmed to id / i2c_id / address / bits_per_sample.
- enable_pin removed; GPIO21 (DAC enable) now driven by a plain gpio switch ("Enable DAC", ALWAYS_ON) replacing `switch: platform: pcm5122`.
- The core component boots the DAC muted, so `audio_dac.mute_off` is called on media_player `on_state` to unmute it.

### Behavioral changes (review)
These sonocotta-only keys have no core equivalent and are dropped:
- `analog_gain: -6dB` -> output ~6 dB louder.
- `volume_max: 0dB` / `volume_min: -60dB` -> digital volume no longer clamped.
- `mixer_mode: STEREO` -> chip default.
- deep-sleep standby toggle (old enable_dac) -> gone.

Tested on hardware (WiFi variant): audio plays well, announcements duck.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
