### PR TITLE
Sync Firmware Channel feature from main into beta

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,0 +1,93 @@
+name: Build and Publish Beta
+
+# Builds CAST-1 firmware from the beta branch and publishes it as assets on a
+# rolling "beta" pre-release. The on-device "Firmware Channel" select points OTA
+# updates at these assets. Stable firmware is built/published separately by
+# build.yml (push to main -> GitHub Pages).
+
+on:
+  push:
+    branches: [beta]
+    paths:
+      - 'Integrations/ESPHome/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    name: Read version
+    runs-on: ubuntu-latest
+    outputs:
+      v: ${{ steps.read.outputs.v }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: read
+        run: |
+          v=$(awk '/substitutions:/ {f=1} f && /version:/ {print $2; exit}' \
+            Integrations/ESPHome/Core.yaml | tr -d '"')
+          echo "v=$v" >> "$GITHUB_OUTPUT"
+          echo "Beta version: $v"
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: version
+    strategy:
+      matrix:
+        include:
+          - { yaml: Integrations/ESPHome/CAST-1_W.yaml,   name: firmware-w }
+          - { yaml: Integrations/ESPHome/CAST-1_ETH.yaml, name: firmware-e }
+    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    with:
+      files: ${{ matrix.yaml }}
+      esphome-version: stable
+      combined-name: ${{ matrix.name }}
+      release-version: ${{ needs.version.outputs.v }}
+
+  publish-beta:
+    name: Publish beta release assets
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: fw
+          pattern: firmware*
+
+      - name: Ensure rolling 'beta' pre-release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view beta -R "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create beta -R "${{ github.repository }}" \
+                 --prerelease --title "Beta (rolling)" \
+                 --notes "Latest CAST-1 beta firmware. Auto-updated on every push to the beta branch."
+
+      - name: Rewrite manifests to absolute URLs and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="https://github.com/${{ github.repository }}/releases/download/beta"
+          for v in w e; do
+            man=$(find "fw/firmware-$v" -name manifest.json | head -1)
+            if [ -z "$man" ]; then
+              echo "::error::manifest.json not found for firmware-$v"
+              exit 1
+            fi
+            echo "Rewriting $man"
+            # Make ota.path and parts[].path absolute release-asset URLs so the
+            # device never has to resolve a relative path against a redirected URL.
+            jq --arg base "$BASE" '
+              .builds[0].ota.path = ($base + "/" + (.builds[0].ota.path | sub(".*/"; "")))
+              | .builds[0].parts[0].path = ($base + "/" + (.builds[0].parts[0].path | sub(".*/"; "")))
+            ' "$man" > "manifest-$v.json"
+            cat "manifest-$v.json"
+            gh release upload beta "manifest-$v.json" -R "${{ github.repository }}" --clobber
+            find "fw/firmware-$v" -name '*.bin' -print -exec \
+              gh release upload beta {} -R "${{ github.repository }}" --clobber \;
+          done
+          echo "Beta assets published."

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -12,8 +12,9 @@ on:
       - 'Integrations/ESPHome/**'
   workflow_dispatch:
 
+# Least privilege: read-only by default; only publish-beta is elevated to write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   version:
@@ -22,7 +23,7 @@ jobs:
     outputs:
       v: ${{ steps.read.outputs.v }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - id: read
         run: |
           v=$(awk '/substitutions:/ {f=1} f && /version:/ {print $2; exit}' \
@@ -38,7 +39,7 @@ jobs:
         include:
           - { yaml: Integrations/ESPHome/CAST-1_W.yaml,   name: firmware-w }
           - { yaml: Integrations/ESPHome/CAST-1_ETH.yaml, name: firmware-e }
-    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/build.yml@e7eee2a828517c042794a831f75310959fbf2a16 # 2025.10.0
     with:
       files: ${{ matrix.yaml }}
       esphome-version: stable
@@ -53,7 +54,7 @@ jobs:
       contents: write
     steps:
       - name: Download firmware artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: fw
           pattern: firmware*
@@ -83,7 +84,7 @@ jobs:
             # device never has to resolve a relative path against a redirected URL.
             jq --arg base "$BASE" '
               .builds[0].ota.path = ($base + "/" + (.builds[0].ota.path | sub(".*/"; "")))
-              | .builds[0].parts[0].path = ($base + "/" + (.builds[0].parts[0].path | sub(".*/"; "")))
+              | .builds[0].parts |= map(.path = ($base + "/" + (.path | sub(".*/"; ""))))
             ' "$man" > "manifest-$v.json"
             cat "manifest-$v.json"
             gh release upload beta "manifest-$v.json" -R "${{ github.repository }}" --clobber

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -39,6 +39,11 @@ ota:
 
 http_request:
   verify_ssl: true
+  # Beta OTA manifests/binaries are GitHub release assets, which 302-redirect to
+  # long signed CDN URLs (~900+ bytes). The default 512-byte RX buffer overflows
+  # ("Out of buffer"), so enlarge it. See esphome/esphome#13786.
+  buffer_size_rx: 4096
+  buffer_size_tx: 1024
 
 safe_mode:
 
@@ -73,17 +78,7 @@ select:
     initial_option: "Ethernet"
     on_value:
       then:
-        - if:
-            condition:
-              lambda: 'return id(firmware_selector).current_option() == "Ethernet";'
-            then:
-              - logger.log: "OTA updates set to use ethernet firmware"
-              - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-e/manifest.json");
-              - component.update: update_http_request
-            else:
-              - logger.log: "OTA updates set to use wifi firmware"
-              - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json");
-              - component.update: update_http_request
+        - script.execute: apply_ota_source
 
 text_sensor:
   - platform: ethernet_info

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -39,6 +39,11 @@ ota:
 
 http_request:
   verify_ssl: true
+  # Beta OTA manifests/binaries are GitHub release assets, which 302-redirect to
+  # long signed CDN URLs (~900+ bytes). The default 512-byte RX buffer overflows
+  # ("Out of buffer"), so enlarge it. See esphome/esphome#13786.
+  buffer_size_rx: 4096
+  buffer_size_tx: 1024
 
 safe_mode:
 
@@ -82,17 +87,7 @@ select:
     initial_option: "WiFi"
     on_value:
       then:
-        - if:
-            condition:
-              lambda: 'return id(firmware_selector).current_option() == "Ethernet";'
-            then:
-              - logger.log: "OTA updates set to use ethernet firmware"
-              - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-e/manifest.json");
-              - component.update: update_http_request
-            else:
-              - logger.log: "OTA updates set to use wifi firmware"
-              - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json");
-              - component.update: update_http_request
+        - script.execute: apply_ota_source
 
 text_sensor:
   - platform: wifi_info

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -188,6 +188,22 @@ number:
     initial_value: 50
     optimistic: true
 
+select:
+  - platform: template
+    id: firmware_channel
+    name: "Firmware Channel"
+    icon: "mdi:source-branch"
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - "Main"
+      - "Beta"
+    initial_option: "Main"
+    on_value:
+      then:
+        - script.execute: apply_ota_source
+
 remote_receiver:
   pin: 
     number: GPIO07
@@ -342,6 +358,25 @@ media_player:
 
 
 script:
+  - id: apply_ota_source
+    # Sets the OTA source URL from the two selectors: Firmware Type (WiFi/Ethernet)
+    # x Firmware Channel (Main/Beta). Main = GitHub Pages, Beta = GitHub release assets.
+    then:
+      - lambda: |-
+          const bool eth  = id(firmware_selector).state == "Ethernet";
+          const bool beta = id(firmware_channel).state == "Beta";
+          std::string url;
+          if (beta) {
+            url = eth
+              ? "https://github.com/ApolloAutomation/CAST-1/releases/download/beta/manifest-e.json"
+              : "https://github.com/ApolloAutomation/CAST-1/releases/download/beta/manifest-w.json";
+          } else {
+            url = eth
+              ? "https://apolloautomation.github.io/CAST-1/firmware-e/manifest.json"
+              : "https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json";
+          }
+          id(update_http_request).set_source_url(url);
+      - component.update: update_http_request
   - id: statusCheck
     then:
       - if:


### PR DESCRIPTION
Version: 26.6.18.1

## What does this implement/fix?

Syncs the **Firmware Channel** feature from `main` back into `beta`. It went in directly on `main` (commits "Beta Firmware Selector" + "Fix Suggestions"), so `beta` was left missing it and the two branches diverged. This cherry-picks Trevor's commits onto `beta` so they converge again.

Brings:
- `firmware_channel` select (Main / Beta) + `apply_ota_source` script; the `firmware_selector` `on_value` now calls that script.
- `http_request` `buffer_size_rx: 4096` / `buffer_size_tx: 1024` on both device configs (GitHub release assets 302-redirect to long signed CDN URLs that overflow the default 512-byte RX buffer).
- `.github/workflows/build-beta.yml`.

Cherry-picked as-is (original author preserved), so no version bump — it lands at `26.6.18.1`, matching `main`.

Validated with `esphome config` on both variants on esphome 2026.6.0.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
