### PR TITLE
Sync beta up to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7.0.0
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7
         with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -19,7 +19,7 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7.0.0
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7
         with:


### PR DESCRIPTION
beta is strictly behind main (it's an ancestor, zero unique commits). The Firmware Channel feature, the dependabot actions/checkout bump, and the earlier sync merges all went onto main without flowing back, so this brings beta up to match.

Cleanest result is a fast-forward (`git push origin main:beta`), which makes beta identical to main with no merge commit. This PR is the reviewable equivalent if you'd rather merge it through the UI.

Supersedes #33 (which cherry-picked just the firmware-channel feature and would have duplicated commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)