### PR TITLE
README: document WizMote Home Assistant control + blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 Easily make your speakers smart and cast to multiple devices using Music Assistant and Sendspin!
 
+## WizMote
+
+The CAST-1 gives you full Home Assistant control over a paired Wiz WizMote. Each of the nine buttons (On, Off, Night, Brightness Up/Down, and 1–4) is a configurable select on the device — assign it Play, Pause, Play / Pause, Next/Previous Track, Volume Up/Down, Toggle Light, or Send HA Event. The defaults give you media controls out of the box.
+
+Set any button to **Send HA Event** to trigger a custom Home Assistant action — play a Music Assistant playlist, toggle a room's lights, run a scene or script.
+
+Configure every button without leaving Home Assistant using the [CAST-1 WizMote blueprint](https://github.com/ApolloAutomation/Blueprints/tree/main/CAST-1):
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2FApolloAutomation%2FBlueprints%2Fblob%2Fmain%2FCAST-1%2FCAST-1-WizMote.yaml)
+
 Links: \
 Discord (Support/feedback/discussion/future products): [http://dsc.gg/ApolloAutomation](http://dsc.gg/ApolloAutomation) \
 Shop: [https://apolloautomation.com](https://apolloautomation.com) \


### PR DESCRIPTION
Documents the new WizMote Home Assistant control (per-button selects + Send HA Event) added in #35, and links the CAST-1 WizMote blueprint (ApolloAutomation/Blueprints#16) with a one-click import badge.

README only — no firmware change.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [x] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)