### PR TITLE
Remove unused IR remote_receiver (IR removed from PCB)

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.6.19.3"
+  version: "26.6.22.1"
 
 packages:
   wizmote: !include wizmote.yaml
@@ -206,14 +206,6 @@ select:
     on_value:
       then:
         - script.execute: apply_ota_source
-
-remote_receiver:
-  pin: 
-    number: GPIO07
-    inverted: true
-    mode:
-      input: true
-  dump: all
 
 audio_dac:
   - platform: pcm5122


### PR DESCRIPTION
Version: 26.6.22.1

## What does this implement/fix?

Trevor removed the IR hardware from the CAST-1 PCB. `Core.yaml` still configured a `remote_receiver` on GPIO07 with `dump: all`, which:

- nothing consumed (no `remote_receiver` binary_sensors, no on-receive actions anywhere)
- left `dump: all` logging every received frame as debug noise

Removes the block. No other file references `remote_receiver` or GPIO07.

Closes #16

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)