### PR TITLE
Rename Firmware Channel option Main to Stable

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.7.7.1"
+  version: "26.7.7.2"
 
 
 packages:
@@ -201,9 +201,9 @@ select:
     optimistic: true
     restore_value: true
     options:
-      - "Main"
+      - "Stable"
       - "Beta"
-    initial_option: "Main"
+    initial_option: "Stable"
     on_value:
       then:
         - script.execute: apply_ota_source
@@ -356,7 +356,8 @@ media_player:
 script:
   - id: apply_ota_source
     # Sets the OTA source URL from the two selectors: Firmware Type (WiFi/Ethernet)
-    # x Firmware Channel (Main/Beta). Main = GitHub Pages, Beta = GitHub release assets.
+    # x Firmware Channel (Stable/Beta). Stable = GitHub Pages (main branch builds),
+    # Beta = GitHub release assets.
     then:
       - lambda: |-
           const bool eth  = id(firmware_selector).current_option() == "Ethernet";


### PR DESCRIPTION
Version: 26.7.7.2

## What does this implement/fix?

Renames the Firmware Channel select options from Main/Beta to Stable/Beta
(and the initial option to "Stable"). "Stable" is clearer than "Main" for
users who don't know the branch layout, and matches the naming used by the
AIR-1 firmware channel feature (ApolloAutomation/AIR-1#107).

No functional change: the update-source logic keys off "Beta", and devices
that stored "Main" fall back to the initial option, which is the same
channel. Both variants config-validated on ESPHome 2026.6.4.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
