### PR TITLE
Fix label check on fork-submitted PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,11 @@ on:
   pull_request:
 
 permissions:
-  pull-requests: write
-  issues: write
   contents: read
 
+# Label check lives in label-check.yml on pull_request_target so it can
+# label fork-submitted PRs; plain pull_request tokens are read-only there.
 jobs:
-  label-check:
-    name: Label Check
-    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main
-
   ci:
     name: CI
     uses: ApolloAutomation/Workflows/.github/workflows/esphome-ci.yml@main

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,20 @@
+name: Label Check
+
+# pull_request_target (not pull_request) so the job gets a write token on
+# fork-submitted PRs too; plain pull_request runs from forks are read-only
+# and cannot add labels. Safe because the called workflow only reads the PR
+# body and never checks out or executes PR code. The "edited" type re-runs
+# the check when the template checkboxes are changed.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  label-check:
+    name: Label Check
+    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main


### PR DESCRIPTION
Version: no bump (workflows only, does not publish)

## What does this implement/fix?

Label check fails on fork-submitted PRs (e.g. #43: "Apply Single Label"
step) because it runs inside ci.yml under plain pull_request, which gets a
read-only token for forks. Moves it to a standalone workflow on
pull_request_target so it gets a write token, matching the fix already
rolled out to the other product repos in June (e.g. AIR-1). Safe because
the called workflow only reads the PR body and never checks out or executes
PR code; the shared workflow was hardened for pull_request_target callers
in ApolloAutomation/Workflows when the other repos switched. ci.yml
permissions are trimmed to contents: read since the build jobs need nothing
more.

Takes effect once merged to the default branch (pull_request_target runs
the base branch's workflow definition), so it won't turn #43 green
retroactively — #43 already has its label applied manually.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [x] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
