### PR TITLE
Rename rolling beta release tag to beta-fw (branch/tag collision)

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -59,12 +59,12 @@ jobs:
           path: fw
           pattern: firmware*
 
-      - name: Ensure rolling 'beta' pre-release exists
+      - name: Ensure rolling 'beta-fw' pre-release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release view beta -R "${{ github.repository }}" >/dev/null 2>&1 \
-            || gh release create beta -R "${{ github.repository }}" \
+          gh release view beta-fw -R "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create beta-fw -R "${{ github.repository }}" \
                  --prerelease --title "Beta (rolling)" \
                  --notes "Latest CAST-1 beta firmware. Auto-updated on every push to the beta branch."
 
@@ -72,7 +72,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BASE="https://github.com/${{ github.repository }}/releases/download/beta"
+          BASE="https://github.com/${{ github.repository }}/releases/download/beta-fw"
           for v in w e; do
             man=$(find "fw/firmware-$v" -name manifest.json | head -1)
             if [ -z "$man" ]; then
@@ -87,8 +87,8 @@ jobs:
               | .builds[0].parts |= map(.path = ($base + "/" + (.path | sub(".*/"; ""))))
             ' "$man" > "manifest-$v.json"
             cat "manifest-$v.json"
-            gh release upload beta "manifest-$v.json" -R "${{ github.repository }}" --clobber
+            gh release upload beta-fw "manifest-$v.json" -R "${{ github.repository }}" --clobber
             find "fw/firmware-$v" -name '*.bin' -print -exec \
-              gh release upload beta {} -R "${{ github.repository }}" --clobber \;
+              gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
           done
           echo "Beta assets published."

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.7.7.2"
+  version: "26.7.8.1"
 
 
 packages:
@@ -365,8 +365,8 @@ script:
           std::string url;
           if (beta) {
             url = eth
-              ? "https://github.com/ApolloAutomation/CAST-1/releases/download/beta/manifest-e.json"
-              : "https://github.com/ApolloAutomation/CAST-1/releases/download/beta/manifest-w.json";
+              ? "https://github.com/ApolloAutomation/CAST-1/releases/download/beta-fw/manifest-e.json"
+              : "https://github.com/ApolloAutomation/CAST-1/releases/download/beta-fw/manifest-w.json";
           } else {
             url = eth
               ? "https://apolloautomation.github.io/CAST-1/firmware-e/manifest.json"


### PR DESCRIPTION
Version: 26.7.8.1

## What does this implement/fix?

The rolling pre-release created a tag named `beta`, colliding with the `beta` branch. git resolves a bare fetch refspec to `refs/tags/` before `refs/heads/`, so ESPHome remote packages pinned to `ref: beta` silently fetch the tag - which was frozen at creation time and never moves - instead of the branch tip. Users following beta as a package get stale YAML no matter how often they clean caches.

Reproduced end-to-end with an isolated cache: ESPHome's `git.py` runs `git fetch --depth=1 -- origin beta` then `git reset --hard FETCH_HEAD`, and `.git/FETCH_HEAD` shows `tag 'beta'` being fetched. CAST-1 has the identical collision (this pattern originated here and was inherited by the other product repos): its `beta` tag is frozen at `1b1066e` while the branch has moved on.

Fix: rename the release tag to `beta-fw` and update the beta manifest URLs to match. After this merges and the renamed release is populated by the next beta build, the old `beta` release + tag should be deleted. Until then, affected users can pin `ref: refs/heads/beta`.

Both variants config-validated on ESPHome 2026.6.4.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
