### PR TITLE
Default the Firmware Channel select to Beta on beta-channel builds

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -37,8 +37,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { yaml: Integrations/ESPHome/CAST-1_W.yaml,   name: firmware-w }
-          - { yaml: Integrations/ESPHome/CAST-1_ETH.yaml, name: firmware-e }
+          - { yaml: Integrations/ESPHome/beta-channel/CAST-1_W.yaml,   name: firmware-w }
+          - { yaml: Integrations/ESPHome/beta-channel/CAST-1_ETH.yaml, name: firmware-e }
     uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
     with:
       files: ${{ matrix.yaml }}

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,10 @@
 substitutions:
-  version: "26.7.8.1"
+  version: "26.7.8.2"
+  # Default update channel on first boot (no stored user choice yet, i.e. a
+  # fresh flash). The beta-channel builds override this to "Beta" (see
+  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
+  # channel keeps tracking it instead of offering a stable "downgrade".
+  firmware_channel_default: "Stable"
 
 
 packages:
@@ -203,7 +208,7 @@ select:
     options:
       - "Stable"
       - "Beta"
-    initial_option: "Stable"
+    initial_option: "${firmware_channel_default}"
     on_value:
       then:
         - script.execute: apply_ota_source

--- a/Integrations/ESPHome/beta-channel/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/beta-channel/CAST-1_ETH.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of CAST-1_ETH.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use CAST-1_ETH.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../CAST-1_ETH.yaml

--- a/Integrations/ESPHome/beta-channel/CAST-1_W.yaml
+++ b/Integrations/ESPHome/beta-channel/CAST-1_W.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of CAST-1_W.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use CAST-1_W.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../CAST-1_W.yaml


### PR DESCRIPTION
Version: 26.7.8.2

## What does this implement/fix?

A fresh flash has no stored channel preference, so the Firmware Channel select fell back to "Stable" even on firmware obtained from the beta channel - and the update entity then offered the older stable build as a "downgrade".

- `initial_option` becomes a substitution (`firmware_channel_default`, still `"Stable"` - stable/Pages builds are byte-identical to before).
- New 8-line `beta-channel/` wrapper yamls override it to `"Beta"`, same override pattern the repos already use for variant wrappers; `build-beta.yml` now builds the wrappers.
- Net effect: firmware downloaded from the beta channel (or flashed from the `beta-fw` release page) boots with the select on Beta and keeps tracking beta. `restore_value` semantics unchanged - the default only applies when no stored choice exists.

Wrapper renders verified locally: base `CAST-1_W.yaml` -> `initial_option: Stable`, `beta-channel/CAST-1_W.yaml` -> `initial_option: Beta`. All four configs validate on ESPHome 2026.6.4.

Same pattern as ApolloAutomation/MSR-1#92.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
