### PR TITLE
Unified firmware: runtime Bluetooth Proxy switch + channel fix set

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -37,8 +37,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { yaml: Integrations/ESPHome/CAST-1_W.yaml,   name: firmware-w }
-          - { yaml: Integrations/ESPHome/CAST-1_ETH.yaml, name: firmware-e }
+          - { yaml: Integrations/ESPHome/beta-channel/CAST-1_W.yaml,   name: firmware-w }
+          - { yaml: Integrations/ESPHome/beta-channel/CAST-1_ETH.yaml, name: firmware-e }
     uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
     with:
       files: ${{ matrix.yaml }}

--- a/Integrations/ESPHome/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/CAST-1_ETH.yaml
@@ -37,14 +37,6 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-  # Beta OTA manifests/binaries are GitHub release assets, which 302-redirect to
-  # long signed CDN URLs (~900+ bytes). The default 512-byte RX buffer overflows
-  # ("Out of buffer"), so enlarge it. See esphome/esphome#13786.
-  buffer_size_rx: 4096
-  buffer_size_tx: 1024
-
 safe_mode:
 
 update:

--- a/Integrations/ESPHome/CAST-1_W.yaml
+++ b/Integrations/ESPHome/CAST-1_W.yaml
@@ -37,14 +37,6 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-  # Beta OTA manifests/binaries are GitHub release assets, which 302-redirect to
-  # long signed CDN URLs (~900+ bytes). The default 512-byte RX buffer overflows
-  # ("Out of buffer"), so enlarge it. See esphome/esphome#13786.
-  buffer_size_rx: 4096
-  buffer_size_tx: 1024
-
 safe_mode:
 
 improv_serial:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,9 +1,39 @@
 substitutions:
-  version: "26.7.8.1"
+  version: "26.7.12.1"
+  # Default update channel on first boot (no stored user choice yet, i.e. a
+  # fresh flash). The beta-channel builds override this to "Beta" (see
+  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
+  # channel keeps tracking it instead of offering a stable "downgrade".
+  firmware_channel_default: "Stable"
+  # Manifest URL bases. Stable = GitHub Pages (main branch builds).
+  # Beta = rolling "beta-fw" pre-release assets (beta branch builds).
+  stable_manifest_base: "https://apolloautomation.github.io/CAST-1"
+  beta_manifest_base: "https://github.com/ApolloAutomation/CAST-1/releases/download/beta-fw"
 
 
 packages:
   wizmote: !include wizmote.yaml
+
+esphome:
+  # List form so package merging concatenates with each variant's own on_boot
+  # entries (mapping form would be replaced by the variant's block instead).
+  on_boot:
+    # Point the update entity at the selected type/channel manifest.
+    - priority: -100
+      then:
+        - script.execute: apply_ota_source
+    # Re-apply the Bluetooth Proxy switch after all components set up, so BLE
+    # scanning matches the persisted switch (proxy stays off by default).
+    - priority: -300
+      then:
+        - if:
+            condition:
+              switch.is_on: bluetooth_proxy_switch
+            then:
+              - esp32_ble_tracker.start_scan:
+                  continuous: true
+            else:
+              - esp32_ble_tracker.stop_scan:
 
 esp32:
   variant: ESP32S3
@@ -25,6 +55,15 @@ esp32:
 
       CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC: "y"
       CONFIG_MBEDTLS_SSL_PROTO_TLS1_3: "y"
+
+# BT allocations go to PSRAM first (CONFIG_BT_* options above), keeping
+# internal RAM free for the audio pipelines.
+esp32_ble_tracker:
+  id: ble_tracker
+  scan_parameters:
+    continuous: true
+
+bluetooth_proxy:
 
 api:
 
@@ -67,6 +106,17 @@ web_server:
   port: 80
   version: 3
 
+http_request:
+  verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
+
 i2c:
   sda: GPIO47
   scl: GPIO48
@@ -79,11 +129,17 @@ button:
   - platform: template
     name: "Firmware Update"
     id: update_firmware
+    icon: mdi:cloud-download
     entity_category: config
     on_press:
-      then:
-        - lambda: |-
-            id(update_http_request).perform(true);
+      - logger.log: "Applying firmware update for the selected type and channel"
+      - delay: 3s
+      - script.execute: apply_ota_source
+      - script.wait: apply_ota_source
+      # The manifest fetch runs in its own task; give it a fixed window to land
+      # (update.is_available stays false for same-version switches).
+      - delay: 5s
+      - lambda: id(update_http_request).perform(true);
 
 binary_sensor:
   - platform: status
@@ -138,6 +194,19 @@ switch:
     name: Enable DAC
     id: enable_dac
     restore_mode: ALWAYS_ON
+
+  - platform: template
+    name: "Bluetooth Proxy"
+    id: bluetooth_proxy_switch
+    icon: mdi:bluetooth
+    entity_category: "config"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - esp32_ble_tracker.start_scan:
+          continuous: true
+    on_turn_off:
+      - esp32_ble_tracker.stop_scan:
 
 text_sensor:
   - platform: sendspin
@@ -210,7 +279,7 @@ select:
     options:
       - "Stable"
       - "Beta"
-    initial_option: "Stable"
+    initial_option: "${firmware_channel_default}"
     on_value:
       then:
         - script.execute: apply_ota_source
@@ -377,7 +446,7 @@ script:
   - id: apply_ota_source
     # Sets the OTA source URL from the two selectors: Firmware Type (WiFi/Ethernet)
     # x Firmware Channel (Stable/Beta). Stable = GitHub Pages (main branch builds),
-    # Beta = GitHub release assets.
+    # Beta = rolling "beta-fw" release assets.
     then:
       - lambda: |-
           const bool eth  = id(firmware_selector).current_option() == "Ethernet";
@@ -385,13 +454,14 @@ script:
           std::string url;
           if (beta) {
             url = eth
-              ? "https://github.com/ApolloAutomation/CAST-1/releases/download/beta-fw/manifest-e.json"
-              : "https://github.com/ApolloAutomation/CAST-1/releases/download/beta-fw/manifest-w.json";
+              ? "${beta_manifest_base}/manifest-e.json"
+              : "${beta_manifest_base}/manifest-w.json";
           } else {
             url = eth
-              ? "https://apolloautomation.github.io/CAST-1/firmware-e/manifest.json"
-              : "https://apolloautomation.github.io/CAST-1/firmware-w/manifest.json";
+              ? "${stable_manifest_base}/firmware-e/manifest.json"
+              : "${stable_manifest_base}/firmware-w/manifest.json";
           }
+          ESP_LOGI("firmware", "OTA manifest set to: %s", url.c_str());
           id(update_http_request).set_source_url(url);
       - component.update: update_http_request
   - id: statusCheck

--- a/Integrations/ESPHome/beta-channel/CAST-1_ETH.yaml
+++ b/Integrations/ESPHome/beta-channel/CAST-1_ETH.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of CAST-1_ETH.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use CAST-1_ETH.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../CAST-1_ETH.yaml

--- a/Integrations/ESPHome/beta-channel/CAST-1_W.yaml
+++ b/Integrations/ESPHome/beta-channel/CAST-1_W.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of CAST-1_W.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use CAST-1_W.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../CAST-1_W.yaml


### PR DESCRIPTION
Version: 26.7.12.1

Adds:
- **New: runtime "Bluetooth Proxy" support.** `bluetooth_proxy` + `esp32_ble_tracker` compile into both images with a "Bluetooth Proxy" switch (default off, persisted, re-applied at boot). The existing `CONFIG_BT_*` sdkconfig options (previously unused) now do real work — BT allocations go to PSRAM first, keeping internal RAM free for the audio pipelines. Worth a listen-test with the proxy ON during Music Assistant playback before release, given the group-sync tuning work in flight.
- Boot-time `apply_ota_source` (`on_boot -100`): previously a reboot left the update entity on its compile-time default source until a select fired; now the persisted Type/Channel choice is re-applied every boot.
- The `beta-channel-default` wrapper work, folded in: `beta-channel/` wrappers default the Firmware Channel select to "Beta" on beta builds, so beta-flashed devices keep tracking beta.
- Manifest-base substitutions (`stable_manifest_base` / `beta_manifest_base`) replace the four hardcoded URLs in `apply_ota_source`; the Type (WiFi/Ethernet) × Channel (Stable/Beta) cross is unchanged. This matches the pattern MSR-1 shipped as 26.7.9.1 (ApolloAutomation/MSR-1#100, ApolloAutomation/MSR-1#103, ApolloAutomation/MSR-1#104).

Fixes:
- "Firmware Update" button upgraded from a bare `perform(true)` to the standard flow: `apply_ota_source` + a fixed manifest-fetch window before `perform` (same-version switches never flip `update.is_available`).
- `http_request` consolidated into Core.yaml and buffers raised from 4096/1024 to the fleet-proven 5120/2048 (GitHub's CSP header line measures 3585 bytes; the signed-redirect request line needs the tx headroom).

Breaks:
- Nothing: the Type select keeps its cross-flash behavior; the proxy switch defaults off.

Supersedes #46 (its wrapper content is carried here).

Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In Core.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
