### PR TITLE
Remove Announce Volume

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -387,9 +387,6 @@ media_player:
                 duration: 0.0s
             - wait_until:
                 media_player.is_announcing: external_media_player
-            - delay: 0.75s
-            - media_player.volume_set:
-                id: external_media_player
             - wait_until:
                 - not:
                     media_player.is_announcing: external_media_player
@@ -397,8 +394,6 @@ media_player:
                 id: media_mixer_input
                 decibel_reduction: 0
                 duration: 1.0s
-            - media_player.volume_set:
-                id: external_media_player
             - light.turn_off:
                 id: rgb_light
             - lambda: id(announcement_triggered) = false;

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -85,9 +85,6 @@ globals:
     type: int
     restore_value: no
     initial_value: "0"
-  - id: current_volume
-    type: float
-    initial_value: '0.2'
   - id: announcement_triggered
     type: bool
     initial_value: 'false'
@@ -372,9 +369,7 @@ media_player:
           condition:
             - lambda: return (!id(announcement_triggered));
           then:
-            - lambda: |-
-                id(announcement_triggered) = true;
-                id(current_volume) = id(external_media_player).volume;
+            - lambda: id(announcement_triggered) = true;
             - light.turn_on:
                 id: rgb_light
                 blue: 100%

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.7.16.1"
+  version: "26.7.22.1"
   # Default update channel on first boot (no stored user choice yet, i.e. a
   # fresh flash). The beta-channel builds override this to "Beta" (see
   # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
@@ -251,19 +251,6 @@ light:
           min_brightness: 50%
           max_brightness: 100%
 
-number:
-  - platform: template
-    name: Apollo CAST-1 Announce Volume
-    id: announce_volume
-    icon: mdi:volume-source
-    unit_of_measurement: "%"
-    min_value: 0
-    max_value: 100
-    step: 1
-    restore_value: true
-    initial_value: 50
-    optimistic: true
-
 select:
   - platform: template
     id: firmware_channel
@@ -403,7 +390,6 @@ media_player:
             - delay: 0.75s
             - media_player.volume_set:
                 id: external_media_player
-                volume: !lambda "return id(announce_volume).state / 100.0;"
             - wait_until:
                 - not:
                     media_player.is_announcing: external_media_player
@@ -413,7 +399,6 @@ media_player:
                 duration: 1.0s
             - media_player.volume_set:
                 id: external_media_player
-                volume: !lambda "return id(current_volume);"
             - light.turn_off:
                 id: rgb_light
             - lambda: id(announcement_triggered) = false;


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.7.22.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?
- Removes announce volume. Just uses media volume


## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the firmware version to **26.7.22.1**.

* **Changes**
  * Removed the **configurable announcement volume** control.
  * During announcements, volume behavior has changed: volume is no longer explicitly adjusted and restored automatically; announcement handling now relies on ducking transitions and timing based on the announcement state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->