### PR TITLE
Remove unused current_volume global

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -85,9 +85,6 @@ globals:
     type: int
     restore_value: no
     initial_value: "0"
-  - id: current_volume
-    type: float
-    initial_value: '0.2'
   - id: announcement_triggered
     type: bool
     initial_value: 'false'
@@ -372,9 +369,7 @@ media_player:
           condition:
             - lambda: return (!id(announcement_triggered));
           then:
-            - lambda: |-
-                id(announcement_triggered) = true;
-                id(current_volume) = id(external_media_player).volume;
+            - lambda: id(announcement_triggered) = true;
             - light.turn_on:
                 id: rgb_light
                 blue: 100%


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.7.22.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?
- Follow-up to #56: the volume restore removed there was the only reader of the `current_volume` global. This drops the now write-only global and its assignment in `on_announcement`.
- Targets the `RemoveAnnounceVol` branch so it merges into #56, not beta directly. No version bump for the same reason.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
