### PR TITLE
Add named Factory Reset ESP entity, mark script switch internal

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.7.27.1"
+  version: "26.7.31.1"
   # Manifest URL bases. Stable = GitHub Pages (main branch builds).
   # Beta = rolling "beta-fw" pre-release assets (beta branch builds).
   stable_manifest_base: "https://apolloautomation.github.io/CAST-1"
@@ -180,8 +180,13 @@ sensor:
 
 switch:
   - platform: factory_reset
+    disabled_by_default: True
+    name: "Factory Reset ESP"
+    id: factory_reset_all
+
+  - platform: factory_reset
     id: factory_reset_switch
-    disabled_by_default: true
+    internal: true
 
   - platform: template
     name: "Bluetooth Proxy"


### PR DESCRIPTION
Version: 26.7.31.1

## What does this implement/fix?

CAST-1 had a single `factory_reset` switch, the one the boot button hold script drives, exposed to Home Assistant with `disabled_by_default` and no `name:` set. With no name it falls back to the device name, so there is no usable **Factory Reset ESP** entity on the device page and an unnamed disabled switch shows up instead.

This matches the pattern already used by AIR-1, MSR-2, MTR-1 and TEMP-1:

- **`factory_reset_all`** with `name: "Factory Reset ESP"` and `disabled_by_default: True`, the user-facing entity.
- **`factory_reset_switch`** marked `internal: true`, kept for the boot button hold script, which still calls `id(factory_reset_switch).turn_on()`.

Version bumped to `26.7.31.1`.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [x] Added/updated documentation for the web page

`esphome config` passes on both `CAST-1_W.yaml` and `CAST-1_ETH.yaml`. Not yet flashed to hardware.

The wiki Sensor Definitions page is being updated to **Factory Reset ESP** in a parallel docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Factory Reset ESP” switch, disabled by default, for exposed factory-reset controls.

* **Bug Fixes**
  * Updated the ESPHome version to 26.7.31.1.
  * Kept the existing factory-reset control internal to prevent unintended exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->