### PR TITLE
Replace deprecated rgb_order with channel_colors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.8.26.7"
+  version: "26.8.27.1"
   # Manifest bases: stable=Pages, beta=release assets
   stable_manifest_base: "https://apolloautomation.github.io/CAST-1"
   beta_manifest_base: "https://github.com/ApolloAutomation/CAST-1/releases/download/beta-fw"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -487,7 +487,7 @@ light:
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 4
-    rgb_order: grb
+    channel_colors: GRB
     effects:
       - pulse:
           name: "Slow Pulse"


### PR DESCRIPTION
ESPHome 2026.8.0 replaces `rgb_order` / `is_rgbw` / `is_wrgb` with a single `channel_colors` key on `esp32_rmt_led_strip` ([esphome#18474](https://github.com/esphome/esphome/pull/18474)).

`channel_colors` takes each of `R`, `G`, `B` exactly once, optionally with a single `W`; the value is case-insensitive. No behaviour change — `grb` and `GRB` are equivalent, uppercase to match the ESPHome docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RGB LED strip channel configuration to ensure colors display in the correct GRB order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->