### PR TITLE
Disable the API no-client reboot (MA-only playback fix)

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.8.26.7"
+  version: "26.8.26.8"
   # Manifest bases: stable=Pages, beta=release assets
   stable_manifest_base: "https://apolloautomation.github.io/CAST-1"
   beta_manifest_base: "https://github.com/ApolloAutomation/CAST-1/releases/download/beta-fw"
@@ -271,6 +271,12 @@ bluetooth_proxy:
 
 api:
   id: api_1
+  # A CAST-1 can legitimately run without a Home Assistant API client —
+  # streaming from Music Assistant uses sendspin's own outbound connection.
+  # The default 15-minute no-client reboot would restart such a device mid-
+  # playback every cycle (observed in the field), so it is disabled; crash
+  # recovery remains covered by safe_mode.
+  reboot_timeout: 0s
   encryption:
 
 globals:


### PR DESCRIPTION
## What

Sets `api: reboot_timeout: 0s` (v26.8.26.8). One commit.

## Why

Field finding on 26.8.26.5: a CAST-1 streaming from Music Assistant but not adopted into Home Assistant rebooted mid-playback every ~15 minutes. Sendspin is its own outbound connection, so ESPHome's API component saw no client and fired its default no-client reboot — designed for sensors, wrong for a speaker that can legitimately live on Music Assistant alone.

Verified adversarially against the ESPHome 2026.8.1 source:
- The timer is boot-anchored, matching the observed reset cadence exactly; resets ceased immediately on HA adoption (unit then ran 23+ min past the mark on the same firmware).
- Without the optional `provisioning:` component (which this config doesn't use), the timer also reboots factory-fresh devices waiting in the setup hotspot — so this fix protects onboarding too.
- `0s` disables only the no-client reboot (and its cosmetic warning flag). HA API, entities, the Online sensor, OTA, and safe-mode crash recovery are unaffected. Audit of every reboot site in compiled components found no other timer that can reboot an MA-only device.

## Testing plan

Merging to beta publishes 26.8.26.8 on the Beta channel; bench units on Beta can OTA and soak (expect: unadopted playback runs indefinitely). Promote to main after soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)